### PR TITLE
Final scaffolding of Home; Semantic Tagging

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -174,24 +174,26 @@ h5{
   height:265px;
   width:900px;
   margin-bottom:95px;
-  background-color:rgb(2, 87, 80, .85);
+  background-color: #cccccc;
+  /*background-color:rgb(2, 87, 80, .85);
   -webkit-box-shadow: 0px 0px 20px -2px rgba(0,0,0,0.8);
   -moz-box-shadow: 0px 0px 20px -2px rgba(0,0,0,0.8);
-  box-shadow: 0px 0px 20px -2px rgba(0,0,0,0.8);
+  box-shadow: 0px 0px 20px -2px rgba(0,0,0,0.8);*/
 }
 
 #tagline-info{
   margin:18px;
   padding-top:40px;
-  border-style:dashed;
+  /*border-style:dashed;
   border-width:2px;
-  border-color:#7aa5a2;
+  border-color:#7aa5a2;*/
 }
 
 #tag-body{
   font-family:'Montserrat', sans-serif;
   font-style:italic;
-  color:#b9c7c4;
+  /*color:#b9c7c4;*/
+  color: #fff;
   margin:0 auto;
   width:675px;
   text-align:center;
@@ -473,6 +475,58 @@ h5{
   width: 176px;
   height: 58px;
 }
+
+
+/*          NEWSLETTER SIGNUP SECTION        */
+#newsletter-signup {
+  width: 100%;
+  height: 275px;
+  background-color: #cccccc;
+  padding-top: 70px;
+  padding-bottom: 60px;
+}
+
+.newsletter-signup-Container {
+  width: 680px;
+  height: 273px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+input[type=email], textarea {
+  display: block;
+  width: 671px;
+  margin: 0 auto;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding: 20px 30px;
+  border: 0;
+  border-bottom: 5px solid #ffffff;
+  outline: 0;
+  -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;    /* Firefox, other Gecko */
+  box-sizing: border-box;         /* Opera/IE 8+ */
+  background-color: transparent;
+  color: #ffffff;
+  font-size: 28px;
+  font-family: 'Josefin Sans', sans-serif;
+  font-size: 24px;
+  line-height: 26px;
+  text-align: center;
+  resize: none;
+}
+
+input[type=submit] {
+  width: 151px;
+  height: 43px;
+  margin: 0 auto;
+  margin-top: 40px;
+  background-color: #acacac;
+  text-decoration: none;
+  color: #ffffff;
+  text-align: center;
+}
+
 
 /*          EVENTS PAGE STARTS HERE        */
 

--- a/events.html
+++ b/events.html
@@ -9,21 +9,25 @@
   <link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300,400|Montserrat:300,300i|Playfair+Display:300,300i,400,400i|Quicksand&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/main.css">
 </head>
+
 <body>
+  <h1 class="hidden">TRAA Scaffold</h1>
   <main id="wrapper">
     <div id="header-wrapper">
       <header id="other-head">
+        <h1 class="hidden">Navigation Bar</h1>
         <div id="logo">
           <a href="index.html"><img src="images/anglers-logo.png" alt="Anglers logo"></a>
         </div>
         <nav id="mainnav">
+          <h1 class="hidden">Navigation</h1>
           <ul>
-            <li><a href="index.html">HOME</a><li>
-            <li><a href="about.html">ABOUT</a><li>
-            <li><a href="projects.html">PROJECTS</a><li>
-            <li><a href="events.html" class="selected">EVENTS</a><li>
-            <li><a href="resources.html">RESOURCES</a><li>
-            <li><a href="contact.html">CONTACT</a><li>
+            <li><a href="index.html">HOME</a></li>
+            <li><a href="about.html">ABOUT</a></li>
+            <li><a href="projects.html">PROJECTS</a></li>
+            <li><a href="events.html" class="selected">EVENTS</a></li>
+            <li><a href="resources.html">RESOURCES</a></li>
+            <li><a href="contact.html">CONTACT</a></li>
           </ul>
         </nav>
 
@@ -31,6 +35,7 @@
           <h1>UPCOMING TRAA EVENTS</h1>
           <h2>Participate, Help Out, Have Fun</h2>
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Upcoming Events Info</h1>
             Events & activities are what the TRAA's all about! With frequent events suitable for all ages, the TRAA hosts hands-on educational experiences dedicated to the preservation of the aquatic ecosystems of London & the surrounding area. Support our efforts in our next event and become part of the solution, and part of the TRAA familly.
           </aside>
         </section>
@@ -39,22 +44,29 @@
 
     <section id="events-upcoming">
       <h3><span class="h2-italics">Upcoming</span> Events</h3>
-      <section id="events-new">
+      <div id="events-new">
         <div class="events">
           <div class="events-img"></div>
           <div class="events-txt">
-            <aside class="aside-txt">Fanshawe Conservation Area - May 16 - 17, 2019</aside>
+            <aside class="aside-txt">
+              <h1 class="hidden">Aside - Event Details - Children's Water Festival</h1>
+              Fanshawe Conservation Area - May 16 - 17, 2019
+            </aside>
             <h4>Children's Water Festival</h4>
             <p>The TRAA will be taking part in the "Public Night" portion of the event, Thursday, May 16 from 5:00pm to 8:00pm. It will likely be for kids to cast at fish targets which is as much fun for us as it is for the kids! If you can come out and lend a hand please contact any of the Executive directly or Contact Us by email.</p>
             <button class="events-button">
               LEARN MORE
             </button>
           </div>
-      </div>
+        </div>
+
       <div class="events">
         <div class="events-img"></div>
         <div class="events-txt">
-          <aside class="aside-txt">7:00PM - Wednesday, June 12, 2019</aside>
+          <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Details - TRAA General Meeting</h1>
+            7:00PM - Wednesday, June 12, 2019
+          </aside>
           <h4>TRAA General Meeting</h4>
           <p>There will be a lot going on over the summer so come on out to the June 12th General Meeting so you know all about upcoming events, projects and other neat stuff. We meet at the Western Ontario Fish & Game Protective Association clubhouse at 790 Southdale Road. As always, guests are always welcome.</p>
           <button class="events-button">
@@ -65,7 +77,10 @@
         <div class="events">
           <div class="events-img"></div>
           <div class="events-txt">
-            <aside class="aside-txt">Saturday, July 13, 2019</aside>
+            <aside class="aside-txt">
+              <h1 class="hidden">Aside - Event Details - TRAA Paddle & Fish</h1>
+              Saturday, July 13, 2019
+            </aside>
             <h4>TRAA Paddle & Fish</h4>
             <p>We've picked the date for this year's Paddle & Fish but have yet to decide on the route. So far, the route with the most support is the South Thames River east of London. There will be an email confirming details soon but make sure you block July 13th off on your calendar! Contact us with a route suggestion.</p>
             <button class="events-button">
@@ -76,7 +91,10 @@
         <div class="events">
             <div class="events-img"></div>
             <div class="events-txt">
-              <aside class="aside-txt">Thursdays, July & August, 2019</aside>
+              <aside class="aside-txt">
+                <h1 class="hidden">Aside - Event Details - TRAA Fishing Evenings</h1>
+                Thursdays, July & August, 2019
+              </aside>
               <h4>TRAA Fishing Evenings</h4>
               <p>We'll be heading out to try our luck every<br>Thursday evening in July and August this<br>summer. Keep an eye on your email for
               <br>locations and dates as we organize them.<br><br>Send us your suggestions for venues!
@@ -86,7 +104,7 @@
               </button>
             </div>
         </div>
-      </section>
+      </div>
     </section>
 
     <section id="events-past">
@@ -94,6 +112,7 @@
         <h3><span class="h2-italics">Past</span> Events</h3>
       </div>
       <nav class="events-past-nav">
+        <h1 class="hidden">Past Events Navigation - 2019</h1>
         <ul><li>2019</li><li>2018</li><li>2017</li><li>OLDER</li><ul>
       </nav>
       <div class="past-column">
@@ -101,6 +120,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             Saturday, May 4, 2019
           </aside>
           <h4>Brown Trout Release</h4>
@@ -114,6 +134,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             Sunday, May 5, 2019
           </aside>
           <h4>River Cleanup!</h4>
@@ -126,6 +147,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             Initial Stream Walk, March, 2019
           </aside>
           <h4>Medway Creek Habitat Project</h4>
@@ -139,6 +161,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             February 18 through March 11, 2019
           </aside>
           <h4>Rod Building - Your First Time</h4>
@@ -149,6 +172,7 @@
         </div>
       </div>
       <nav class="events-past-nav">
+        <h1 class="hidden">Pasts Events Navigation 2018</h1>
         <ul><li>2019</li><li>2018</li><li>2017</li><li>OLDER</li><ul>
       </nav>
       <div class="past-column">
@@ -156,6 +180,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             Saturday, October 13, 2018
           </aside>
           <h4>Stream Habitat Work Party</h4>
@@ -170,6 +195,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             Saturday, July 14, 2018
           </aside>
           <h4>Annual TRAA Paddle & Fish</h4>
@@ -182,6 +208,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             Thursday, July 12, 2018
           </aside>
           <h4>Stream Habitat Work Party</h4>
@@ -194,6 +221,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             Saturday, June 30, 2018
           </aside>
           <h4>Work Party - Hatchery Roof</h4>
@@ -204,6 +232,7 @@
         </div>
       </div>
       <nav class="events-past-nav">
+        <h1 class="hidden">Past Events Navigation - 2017</h1>
         <ul><li>2019</li><li>2018</li><li>2017</li><li>OLDER</li><ul>
       </nav>
       <div class="past-column">
@@ -211,6 +240,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             Saturday, June 23, 2017
           </aside>
           <h4>Rainbow Trout Release</h4>
@@ -223,6 +253,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             February 23 to February 25, 2017
           </aside>
           <h4>TRAA - Show Time!</h4>
@@ -234,6 +265,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             Friday, June 16, 2017
           </aside>
           <h4>Rainbow Trout Release</h4>
@@ -246,6 +278,7 @@
         </div>
         <div class="past-txt">
           <aside class="aside-txt">
+            <h1 class="hidden">Aside - Event Date</h1>
             Wednesday, May 17, 2017
           </aside>
           <h4>Brook Trout Release</h4>
@@ -256,15 +289,19 @@
         </div>
       </div>
       <nav class="events-past-nav">
+        <h1 class="hidden">Past Events Navigation - OLDER</h1>
         <ul><li>2019</li><li>2018</li><li>2017</li><li>OLDER</li><ul>
       </nav>
     </section>
 
     <footer id="footer" class="clear">
+      <h1 class="hidden">Footer</h1>
       <section id="footer-info">
+        <h1 class="hidden">Footer Information</h1>
         <section id="quicklinks">
           <h3>Quick Links</h3>
           <nav id="sub-social">
+            <h1 class="hidden">Social Footer Nav</h1>
             <ul>
               <li><a href="https://www.facebook.com/groups/4TRAA/about/" target="_blank"><img src="images/social/sm-facebook.svg" alt="go to facebook page" width="41" height="41"></a></li>
               <li><a href="https://www.youtube.com/channel/UCSuwqQ-HzLQw-gylALz5YkA" target="_blank"><img src="images/social/sm-youtube.svg" alt="go to youtube page" width="41" height="41"></a></li>
@@ -272,6 +309,7 @@
             </ul>
           </nav>
           <nav id="sub-nav">
+            <h1 class="hidden">Pages Footer Nav</h1>
             <div id="sub-nav-1">
               <ul>
                 <li><a href="index.html">HOME</a></li>
@@ -314,6 +352,7 @@
         </section>
       </section>
       <section id="copyright" class="clear">
+        <h1 class="hidden">Copyright</h1>
         <p>ANGLERS.ORG © THAMES RIVER ANGLERS ASSOCIATION 2019</p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -9,66 +9,72 @@
   <link href="https://fonts.googleapis.com/css?family=Josefin+Sans:300,400|Montserrat:300,300i|Playfair+Display:400,400i|Quicksand&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/main.css">
 </head>
+
 <body>
+  <h1 class="hidden">TRAA Scaffold</h1>
   <main id="wrapper">
   	<div id="index-header-wrapper">
     	<header id="index-head">
+    	<h1 class="hidden">Navigation Bar</h1>
       	<div id="logo">
        		<a href="index.html"><img src="images/anglers-logo.png" alt="Anglers logo"></a>
       	</div>
+      	
       	<nav id="mainnav">
+		<h1 class="hidden">Navigation</h1>
        	 <ul>
-       	 	<li><a href="index.html" class="selected">HOME</a><li>
-        	<li><a href="about.html">ABOUT</a><li>
-         	<li><a href="projects.html">PROJECTS</a><li>
-         	<li><a href="events.html">EVENTS</a><li>
-         	<li><a href="resources.html">RESOURCES</a><li>
-        	<li><a href="contact.html">CONTACT</a><li>
+       	 	<li><a href="index.html" class="selected">HOME</a></li>
+        	<li><a href="about.html">ABOUT</a></li>
+         	<li><a href="projects.html">PROJECTS</a></li>
+         	<li><a href="events.html">EVENTS</a></li>
+         	<li><a href="resources.html">RESOURCES</a></li>
+        	<li><a href="contact.html">CONTACT</a></li>
         </ul>
       </nav>
 
-      <section id="tagline" class="clear">
-        <article id="tagline-info">
-          <h1>WELCOME TO THE TRAA</h1>
-          <h2>Dedication <span class="h2-italics">Today</span> for Tomorrow</h2>
-          <aside id="tag-body">
-            <p>"For the enhancement, protection and promotion of a viable,
-            multi-species fishery within the Thames River watershed.”</p>
-          </aside>
-        </article>
-      </section>
-    </header>
-
+    	<section id="tagline" class="clear">
+    		<h1 class="hidden">Welcome Section</h1>
+    		<article id="tagline-info">
+    			<h1>WELCOME TO THE TRAA</h1>
+    			<h2>Dedication <span class="h2-italics">Today</span> for Tomorrow</h2>
+          		<aside id="tag-body">
+            		<p>"For the enhancement, protection and promotion of a viable,
+            		multi-species fishery within the Thames River watershed.”</p>
+          		</aside>
+        	</article>
+    	</section>
+    	</header>
+	</div>
     <section id="call-to-action">
     	<h1 class="hidden">Call to Action</h1>
     	<section class="call-to-action-Cont" id="cta-donate">
-      	<h1>DONATE</h1>
-      	<h2>& FUNDRAISE</h2>
-      	<p>Efforts are underway to raise the funds we need to continue many of the TRAA's most vital projects</p>
-      </section>
+      		<h1>DONATE</h1>
+      		<h2>& FUNDRAISE</h2>
+      		<p>Efforts are underway to raise the funds we need to continue many of the TRAA's most vital projects</p>
+      	</section>
 
-      <section class="call-to-action-Cont" id="cta-membership">
-      	<h1>THE TRAA</h1>
-      	<h2>& MEMBERSHIP</h2>
-      	<p>Become a member and add another voice to help in our efforts in protecting our aquatic habitats for as little as $25/year</p>
-      	<button class="button">
-      		<a href="#">CONTACT US</a>
-      	</button>
-      </section>
+      	<section class="call-to-action-Cont" id="cta-membership">
+      		<h1>THE TRAA</h1>
+      		<h2>& MEMBERSHIP</h2>
+      		<p>Become a member and add another voice to help in our efforts in protecting our aquatic habitats for as little as $25/year</p>
+      		<button class="button">
+      			<a href="#">CONTACT US</a>
+      		</button>
+     	 </section>
 
-      <section class="call-to-action-Cont" id="cta-involvement">
-      	<h1>TAKE ACTION</h1>
-      	<h2>& GET INVOLVED</h2>
-      	<p>From getting involved in our salmoid monitoring program to our Komoka Creek hydrolical study, make a difference today</p>
-      	<button class="button">
-      		<a href="#">LEARN MORE</a>
-      	</button>
-      </section>
+      	<section class="call-to-action-Cont" id="cta-involvement">
+      		<h1>TAKE ACTION</h1>
+      		<h2>& GET INVOLVED</h2>
+      		<p>From getting involved in our salmoid monitoring program to our Komoka Creek hydrolical study, make a difference today</p>
+      		<button class="button">
+      			<a href="#">LEARN MORE</a>
+      		</button>
+      	</section>
     </section>
 
 	<section id="about">
 		<h2><span class="h2-italics">About</span> the TRAA</h2>
-		<section class="about-Cont">
+		<div class="about-Cont">
 			<div class="about-img"></div>
 			<div class="about-txt">
 				<p>In the spring of 1986 the TRAA was formed by anglers concerned with the state of the fishery in the Thames River watershed, particularly the dwindling smallmouth bass population in the North Thames River.
@@ -80,12 +86,12 @@
 					<a href="#">LEARN MORE</a>
 				</button>
 			</div>
-		</section>
+		</div>
 	</section>
 
 	<section id="news">
 		<h3>Latest <span class="h2-italics">News</span></h3>
-		<section class="news-Container">
+		<div class="news-Container">
 			<section class="news-Content">
 				<div class="news-img">
 				</div>
@@ -114,9 +120,10 @@
 					<br><br>Get your TRAA Gear (makes a great Christmas gift!) at any TRAA event, such as this coming General Meeting.</p>
 				</div>
 			</section>
-		</section>
+		</div>
 
 		<section id="news-Navigation">
+			<h1 class="hidden">News Navigation</h1>
 			<div class="leftArrow">
 			</div>
 			<div class="rightArrow">	
@@ -126,15 +133,17 @@
 
 	
 	<section id="events-home">
+		<h1 class="hidden">Events Section</h1>
 		<section class="events-home-title">
 			<h2><span class="h2-italics">Upcoming</span> Events</h2>
 		</section>
 
-		<section class="events-home-Container">
+		<div class="events-home-Container">
 			<section class="events-home-Content">
 				<div class="events-home-img"></div>
 				<h5>TRAA Fishing Evenings</h5>
 				<aside class="events-home-aside">
+					<h1 class="hidden">Aside - Date</h1>
 					THURDAYS, JULY & AUGUST, 2019
 				</aside>
 				<p>We'll be heading out to try our luck every Thursday evening in July and August this summer. Keep an eye on your email for locations and dates as we organize them.</p>
@@ -144,6 +153,7 @@
 				<div class="events-home-img"></div>
 				<h5>The Water Festival</h5>
 				<aside class="events-home-aside">
+					<h1 class="hidden">Aside - Date</h1>
 					JULY & AUGUST, 2019
 				</aside>
 				<p>We'll be heading out to try our luck every Thursday evening in July and August this summer. Keep an eye on your email for locations and dates as we organize them.</p>
@@ -153,6 +163,7 @@
 				<div class="events-home-img"></div>
 				<h5>River Cleanup</h5>
 				<aside class="events-home-aside">
+					<h1 class="hidden">Aside - Date</h1>
 					SUNDAY, MAY 5, 2019
 				</aside>
 				<p>We'll be heading out to try our luck every Thursday evening in July and August this summer. Keep an eye on your email for locations and dates as we organize them.</p>
@@ -162,20 +173,22 @@
 				<div class="events-home-img"></div>
 				<h5>Brown Trout Release</h5>
 				<aside class="events-home-aside">
+					<h1 class="hidden">Aside - Date</h1>
 					SATURDAY, MAY 4, 2019
 				</aside>
 				<p>We'll be heading out to try our luck every Thursday evening in July and August this summer. Keep an eye on your email for locations and dates as we organize them.</p>
 			</section>
-		</section>
+		</div>
 	</section>
 
 	<section id="projects-home">
+		<h1 class="hidden">Projects Section</h1>
 		<section class="projects-home-info">
 			<h3>Current <span class="h2-italics">Projects</span></h3>
 			<p>You'll find us right in the water clearing obstructions from streams, measuring returning salmonids & taking scale samples for DNA analysis, education through trout hatchery tours & stream walks, being a voice for the Thames River watershed & its inhabitants and the list goes on.</p>
 		</section>
 
-		<section class="projects-home-Container">
+		<div class="projects-home-Container">
 			<section class="projects-home-Content">
 				<div class="projects-home-img"></div>
 				<div class="projects-home-txt">
@@ -191,19 +204,33 @@
 					<p>Here's an overview of what happened over a few weekends in the Spring of 2012 when TRAA members & personnel from the Upper Thames River Conservation Authority (UTRCA) waded in for Year 3 of our 5-year 
 				</div>
 			</section>
-		</section>
+		</div>
 
 		<section class="projects-home-button">
+			<h1 class="hidden">Projects Button</h1>
 			<button class="button" id="projects-button">
-				<a href="#">LEARN MORE</a>
+				<a href="#">MORE PROJECTS</a>
 			</button>
 		</section>
 	</section>
+
+	<section id="newsletter-signup">
+		<h1 class="hidden">Newsletter Sign-up Section</h1>
+		<div class="newsletter-signup-Container">
+			<h2>Sign up for our <span class="h2-italics">Newsletter!</span></h2>
+			<input type="email" name="newsletteremail" placeholder="ENTER EMAIL ADDRESS">
+			<input type="submit" value="SUBSCRIBE">
+		</div>
+	</section>
+
     <footer id="footer" class="clear">
+      <h1 class="hidden">Footer</h1>
       <section id="footer-info">
+      	<h1 class="hidden">Footer Information</h1>
         <section id="quicklinks">
           <h3>Quick Links</h3>
           <nav id="sub-social">
+          	<h1 class="hidden">Social Footer Nav</h1>
             <ul>
               <li><a href="https://www.facebook.com/groups/4TRAA/about/" target="_blank"><img src="images/social/sm-facebook.svg" alt="go to facebook page" width="41" height="41"></a></li>
               <li><a href="https://www.youtube.com/channel/UCSuwqQ-HzLQw-gylALz5YkA" target="_blank"><img src="images/social/sm-youtube.svg" alt="go to youtube page" width="41" height="41"></a></li>
@@ -211,6 +238,7 @@
             </ul>
           </nav>
           <nav id="sub-nav">
+          	<h1 class="hidden">Pages Footer Nav</h1>
             <div id="sub-nav-1">
               <ul>
                 <li><a href="index.html">HOME</a></li>
@@ -253,6 +281,7 @@
         </section>
       </section>
       <section id="copyright" class="clear">
+      	<h1 class="hidden">Copyright</h1>
         <p>ANGLERS.ORG © THAMES RIVER ANGLERS ASSOCIATION 2019</p>
       </section>
 


### PR DESCRIPTION
Hi Kateh, here's the final scaffolding of the home!
What I did:
- Added the newsletter section in the homepage
- Fixed the semantic tagging for the Home and Events. You didn't have the proper tags for the sections so I put them in in order for the outline to be organized (uploaded the screenshots below. You can do this through the chrome extension Trevor showed but if you need help with it let me know!)
- The navbar's closing for <li> was also <li> so I changed that to </li>. Make sure to watch out for that in the other pages :)

This is what the Homepage's outline looks like:
<img width="515" alt="Screen Shot 2019-06-08 at 10 48 25 PM" src="https://user-images.githubusercontent.com/46770498/59154430-0c468900-8a40-11e9-9d19-458e8f14ead3.png">
<img width="517" alt="Screen Shot 2019-06-08 at 10 48 31 PM" src="https://user-images.githubusercontent.com/46770498/59154431-0c468900-8a40-11e9-8c88-37a88f4123a4.png">

This what the Event's outline looks like:
<img width="514" alt="Screen Shot 2019-06-08 at 10 48 04 PM" src="https://user-images.githubusercontent.com/46770498/59154434-18324b00-8a40-11e9-98f6-458749f150bc.png">
<img width="516" alt="Screen Shot 2019-06-08 at 10 48 11 PM" src="https://user-images.githubusercontent.com/46770498/59154435-18324b00-8a40-11e9-8d1d-1d73ba3d8c6f.png">
